### PR TITLE
Test the async-react cache store's share semantics, and catalog rxjs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
       - run: pnpm lint
       - run: pnpm knip --reporter github-actions
 
+  demo:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+      - run: pnpm --filter async-react test
+      - run: pnpm --filter async-react build
+
   test:
     needs: build
     runs-on: ${{ matrix.os }}

--- a/async-react/package.json
+++ b/async-react/package.json
@@ -9,6 +9,7 @@
     "dev": "vite",
     "dev:no-compiler": "vite --mode no-compiler",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
@@ -25,7 +26,7 @@
     "react": "canary",
     "react-dom": "canary",
     "react-rx": "workspace:*",
-    "rxjs": "^7.8.2",
+    "rxjs": "catalog:",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0"
@@ -38,7 +39,8 @@
     "@vitejs/plugin-react": "^6.1.1",
     "oxc-transform-react": "^0.149.0",
     "typescript": "7.0.2",
-    "vite": "^8.2.2"
+    "vite": "^8.2.2",
+    "vitest": "^5.0.0"
   },
   "msw": {
     "workerDirectory": [

--- a/async-react/src/data/cache.test.ts
+++ b/async-react/src/data/cache.test.ts
@@ -1,0 +1,114 @@
+import {firstValueFrom, map, throwError, timer, type Observable} from 'rxjs'
+import {afterEach, beforeEach, expect, it, vi} from 'vitest'
+
+import {createObservableCache} from './cache'
+
+const TTL = 5000
+const LATENCY = 10
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** A source that completes, like the fetches the store is built for. */
+function trackedFetch() {
+  let calls = 0
+  const fetch = (id: string) => {
+    calls++
+    return timer(LATENCY).pipe(map(() => `${id}#${calls}`))
+  }
+  return {fetch, calls: () => calls}
+}
+
+/** Subscribe, then let the fake clock run: a cold source starts on subscribe. */
+async function read<T>(source: Observable<T>): Promise<T> {
+  const value = firstValueFrom(source)
+  await vi.advanceTimersByTimeAsync(LATENCY)
+  return value
+}
+
+it('returns the same observable for the same arguments', () => {
+  const cache = createObservableCache((id: string) => timer(LATENCY).pipe(map(() => id)), {
+    ttl: TTL,
+  })
+
+  expect(cache('a')).toBe(cache('a'))
+  expect(cache('a')).not.toBe(cache('b'))
+})
+
+it('dedupes concurrent subscribers into one request', async () => {
+  const {fetch, calls} = trackedFetch()
+  const cache = createObservableCache(fetch, {ttl: TTL})
+  const lessons$ = cache('all')
+
+  const first = firstValueFrom(lessons$)
+  const second = firstValueFrom(lessons$)
+  await vi.advanceTimersByTimeAsync(LATENCY)
+
+  expect(await first).toBe('all#1')
+  expect(await second).toBe('all#1')
+  expect(calls()).toBe(1)
+})
+
+it('replays the result to later subscribers within the ttl', async () => {
+  const {fetch, calls} = trackedFetch()
+  const cache = createObservableCache(fetch, {ttl: TTL})
+
+  expect(await read(cache('all'))).toBe('all#1')
+  await vi.advanceTimersByTimeAsync(TTL - LATENCY - 1)
+
+  expect(await read(cache('all'))).toBe('all#1')
+  expect(calls()).toBe(1)
+})
+
+it('completes a request that lost every subscriber, then replays it', async () => {
+  const {fetch, calls} = trackedFetch()
+  const cache = createObservableCache(fetch, {ttl: TTL})
+
+  cache('all').subscribe().unsubscribe()
+  await vi.advanceTimersByTimeAsync(LATENCY)
+
+  expect(await read(cache('all'))).toBe('all#1')
+  expect(calls()).toBe(1)
+})
+
+it('refetches once the ttl has elapsed', async () => {
+  const {fetch, calls} = trackedFetch()
+  const cache = createObservableCache(fetch, {ttl: TTL})
+
+  expect(await read(cache('all'))).toBe('all#1')
+  await vi.advanceTimersByTimeAsync(TTL)
+
+  expect(await read(cache('all'))).toBe('all#2')
+  expect(calls()).toBe(2)
+})
+
+it('never caches a failure', async () => {
+  let attempts = 0
+  const cache = createObservableCache(
+    () => {
+      attempts++
+      return throwError(() => new Error('lessons endpoint is down'))
+    },
+    {ttl: TTL},
+  )
+
+  await expect(firstValueFrom(cache())).rejects.toThrow('lessons endpoint is down')
+  await expect(firstValueFrom(cache())).rejects.toThrow('lessons endpoint is down')
+  expect(attempts).toBe(2)
+})
+
+it('refetches after clear(), which is what revalidate() relies on', async () => {
+  const {fetch, calls} = trackedFetch()
+  const cache = createObservableCache(fetch, {ttl: TTL})
+
+  expect(await read(cache('all'))).toBe('all#1')
+  cache.clear()
+
+  expect(await read(cache('all'))).toBe('all#2')
+  expect(calls()).toBe(2)
+})

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -81,7 +81,7 @@
     "publint": "^0.3.24",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "rxjs": "^7.8.2",
+    "rxjs": "catalog:",
     "tsdown": "^0.23.0",
     "typescript": "7.0.2",
     "vite": "^8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    rxjs:
+      specifier: ^7.8.2
+      version: 7.8.2
+
 overrides:
   nextra-theme-docs>zod: 4.3.6
 
@@ -162,7 +168,7 @@ importers:
         version: 1.12.0
       lucide-react:
         specifier: ^1.42.0
-        version: 1.42.0(react@19.3.0-canary-6c0e1047-20260908)
+        version: 1.43.0(react@19.3.0-canary-6c0e1047-20260908)
       msw:
         specifier: ^2.15.0
         version: 2.15.0(@types/node@26.5.0)(typescript@7.0.2)
@@ -176,7 +182,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/react-rx
       rxjs:
-        specifier: ^7.8.2
+        specifier: 'catalog:'
         version: 7.8.2
       tailwind-merge:
         specifier: ^3.6.0
@@ -212,6 +218,9 @@ importers:
       vite:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0)
+      vitest:
+        specifier: ^5.0.0
+        version: 5.0.0(@types/node@26.5.0)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.5.0)(typescript@7.0.2))(vite@8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/react-rx:
     devDependencies:
@@ -255,7 +264,7 @@ importers:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
       rxjs:
-        specifier: ^7.8.2
+        specifier: 'catalog:'
         version: 7.8.2
       tsdown:
         specifier: ^0.23.0
@@ -268,7 +277,7 @@ importers:
         version: 8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
         specifier: ^5.0.0
-        version: 5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
 
   website:
     dependencies:
@@ -309,7 +318,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/react-rx
       rxjs:
-        specifier: ^7.8.2
+        specifier: 'catalog:'
         version: 7.8.2
       styled-components:
         specifier: ^6.5.3
@@ -3830,8 +3839,8 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
-  lucide-react@1.42.0:
-    resolution: {integrity: sha512-b3jprplnoLS8n5etw1z8xODe3hF/yjKATrTitsrKrnjUhCef5BdDct6Ppv3zVvzFwmtfWgLO6XNM3C9fAD93ug==}
+  lucide-react@1.43.0:
+    resolution: {integrity: sha512-ubtnda1fVK5ky0PNEpOmB0wiwhpZUyJiol4K14KCm+QKvuCkfUu54Et/rIjyupJpwiJ5Hg+BLQE86/GEsS+IgQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -5389,7 +5398,7 @@ snapshots:
 
   '@codesandbox/nodebox@0.1.8':
     dependencies:
-      outvariant: 1.4.3
+      outvariant: 1.4.0
       strict-event-emitter: 0.4.6
 
   '@codesandbox/sandpack-client@2.19.8':
@@ -5638,33 +5647,12 @@ snapshots:
 
   '@inquirer/ansi@2.0.8': {}
 
-  '@inquirer/confirm@6.3.2(@types/node@24.13.3)':
-    dependencies:
-      '@inquirer/core': 12.0.3(@types/node@24.13.3)
-      '@inquirer/type': 4.1.1(@types/node@24.13.3)
-    optionalDependencies:
-      '@types/node': 24.13.3
-    optional: true
-
   '@inquirer/confirm@6.3.2(@types/node@26.5.0)':
     dependencies:
       '@inquirer/core': 12.0.3(@types/node@26.5.0)
       '@inquirer/type': 4.1.1(@types/node@26.5.0)
     optionalDependencies:
       '@types/node': 26.5.0
-
-  '@inquirer/core@12.0.3(@types/node@24.13.3)':
-    dependencies:
-      '@inquirer/ansi': 2.0.8
-      '@inquirer/figures': 2.0.9
-      '@inquirer/type': 4.1.1(@types/node@24.13.3)
-      cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.2
-      mute-stream: 3.0.0
-      signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 24.13.3
-    optional: true
 
   '@inquirer/core@12.0.3(@types/node@26.5.0)':
     dependencies:
@@ -5679,11 +5667,6 @@ snapshots:
       '@types/node': 26.5.0
 
   '@inquirer/figures@2.0.9': {}
-
-  '@inquirer/type@4.1.1(@types/node@24.13.3)':
-    optionalDependencies:
-      '@types/node': 24.13.3
-    optional: true
 
   '@inquirer/type@4.1.1(@types/node@26.5.0)':
     optionalDependencies:
@@ -7089,14 +7072,23 @@ snapshots:
     optionalDependencies:
       oxc-transform-react: 0.149.0
 
-  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@7.0.2))(vite@8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@vitest/spy': 5.0.0
       estree-walker: 3.0.3
       magic-string: 1.2.3
     optionalDependencies:
-      msw: 2.15.0(@types/node@24.13.3)(typescript@7.0.2)
+      msw: 2.15.0(@types/node@26.5.0)(typescript@7.0.2)
+      vite: 8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/mocker@5.0.0(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
+      estree-walker: 3.0.3
+      magic-string: 1.2.3
+    optionalDependencies:
       vite: 8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
 
   '@vitest/spy@5.0.0': {}
@@ -8261,7 +8253,7 @@ snapshots:
 
   lru-cache@11.5.2: {}
 
-  lucide-react@1.42.0(react@19.3.0-canary-6c0e1047-20260908):
+  lucide-react@1.43.0(react@19.3.0-canary-6c0e1047-20260908):
     dependencies:
       react: 19.3.0-canary-6c0e1047-20260908
 
@@ -8816,32 +8808,6 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
-
-  msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2):
-    dependencies:
-      '@inquirer/confirm': 6.3.2(@types/node@24.13.3)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.2
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.2
-      type-fest: 5.9.0
-      until-async: 3.0.2
-      yargs: 17.7.3
-    optionalDependencies:
-      typescript: 7.0.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   msw@2.15.0(@types/node@26.5.0)(typescript@7.0.2):
     dependencies:
@@ -9644,7 +9610,7 @@ snapshots:
       '@open-draft/deferred-promise': 2.2.0
       dotenv: 16.6.1
       mime-db: 1.54.0
-      outvariant: 1.4.3
+      outvariant: 1.4.0
 
   statuses@2.0.2: {}
 
@@ -9994,10 +9960,10 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 5.0.0(vite@8.2.2(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
       chai: 6.2.2
       es-module-lexer: 2.3.2
       expect-type: 1.4.0
@@ -10012,6 +9978,28 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@5.0.0(@types/node@26.5.0)(jsdom@30.0.1)(msw@2.15.0(@types/node@26.5.0)(typescript@7.0.2))(vite@8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@7.0.2))(vite@8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0))
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 6.1.4
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      vite: 8.2.2(@types/node@26.5.0)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.5.0
       jsdom: 30.0.1
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,9 @@ packages:
   - 'website'
   - 'async-react'
 
+catalog:
+  rxjs: ^7.8.2
+
 allowBuilds:
   es5-ext: false
   esbuild: false

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-rx": "workspace:*",
-    "rxjs": "^7.8.2",
+    "rxjs": "catalog:",
     "styled-components": "^6.5.3",
     "typescript": "6.0.3",
     "use-error-boundary": "^2.0.6"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Rebased onto the latest `current` as a single commit.

Three changes:

**`rxjs` moves into the pnpm catalog.** `async-react`, `website`, and `packages/react-rx` reference `catalog:` while `react-rx`'s peer range remains `^7.2`. `pnpm why rxjs` reports one resolved `rxjs@7.8.2`.

**Tests for `cache.ts`.** Seven fake-timer tests cover request deduplication, TTL replay and refetch, orphaned-request completion, uncached errors, stable keyed identity, and `clear()` revalidation.

**CI runs the demo.** The `demo` job runs the demo tests and Vite build.

## Conflict resolution

The only conflict with `current` was generated content in `pnpm-lock.yaml`: this PR added the demo's Vitest dependency while `current` updated shared dependency versions. The package manifests merged cleanly, so the lockfile was regenerated with pnpm to preserve both changes. No product or API intents conflicted.

## Verification

`pnpm why rxjs` reports one version. Focused tests, typecheck, lint, knip, and the affected package test are run after the rebase.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7d4636b-cd81-4bce-8943-3549ad5918f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7d4636b-cd81-4bce-8943-3549ad5918f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

