### PR TITLE
Vendor the useEffectEvent ponyfill from use-effect-event@1.0.2

### DIFF
--- a/.changeset/vendor-use-effect-event.md
+++ b/.changeset/vendor-use-effect-event.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Vendor the `use-effect-event` ponyfill so effect events keep a stable identity under React Compiler, and drop the runtime dependency.

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -67,9 +67,6 @@
     "test": "vitest run --typecheck",
     "watch": "tsdown --watch"
   },
-  "dependencies": {
-    "use-effect-event": "^2.0.3"
-  },
   "devDependencies": {
     "@sanity/tsconfig": "^2.2.1",
     "@sanity/tsdown-config": "^0.26.2",

--- a/packages/react-rx/src/__tests__/useEffectEvent.test.tsx
+++ b/packages/react-rx/src/__tests__/useEffectEvent.test.tsx
@@ -42,12 +42,39 @@ function expectLatestValue(useEvent: EffectEventHook, componentType: ComponentTy
   expect(seen).toEqual([0, 1])
 }
 
+function expectStableIdentity(useEvent: EffectEventHook) {
+  const identities = new Set<() => void>()
+
+  function Component({value}: {value: number}) {
+    identities.add(
+      useEvent(() => {
+        void value
+      }),
+    )
+    return null
+  }
+
+  const {rerender} = render(<Component value={0} />)
+  rerender(<Component value={1} />)
+  rerender(<Component value={2} />)
+
+  expect(identities.size).toBe(1)
+}
+
 describe('useEffectEvent', () => {
   for (const componentType of componentTypes) {
     test(`sees the latest value in ${componentType} components`, () => {
       expectLatestValue(useEffectEvent, componentType)
     })
   }
+
+  // React Compiler only leaves `useEffectEvent` out of the dependencies it
+  // infers when the hook is React's own, so a ponyfill has to keep a stable
+  // identity. React's native hook and `use-effect-event@2` both return a fresh
+  // function per render and would fail this.
+  test('returns the same callback across renders', () => {
+    expectStableIdentity(useEffectEvent)
+  })
 })
 
 describe('React.useEffectEvent', () => {

--- a/packages/react-rx/src/useEffectEvent.ts
+++ b/packages/react-rx/src/useEffectEvent.ts
@@ -1,5 +1,27 @@
+import {useCallback, useInsertionEffect, useRef} from 'react'
+
+// Vendored from `use-effect-event@1.0.2`:
+// https://github.com/sanity-io/use-effect-event/blob/v1.0.2/src/useEffectEvent.ts
+// React Compiler only leaves `useEffectEvent` out of the dependencies it infers
+// when the hook is React's own. Any other implementation is treated as an
+// ordinary value, so its identity has to be stable across renders or every memo
+// block and effect that closes over it invalidates on each render. React's
+// native hook and `use-effect-event@2` both return a fresh function per render,
+// which is safe for the native hook and not for a ponyfill; the `useCallback`
+// wrapper below is what keeps this one usable under the compiler.
+//
 // TODO: switch to `useEffectEvent` from `react` once
 // https://github.com/facebook/react/issues/34818 is fixed in the lowest React
 // version we support. React 19.2 keeps first-render values when the calling
 // component is wrapped in `forwardRef` or `memo`.
-export {useEffectEvent} from 'use-effect-event'
+/** @internal */
+export function useEffectEvent<const T extends (...args: any[]) => void>(fn: T): T {
+  const ref = useRef<T | null>(null)
+  useInsertionEffect(() => {
+    ref.current = fn
+  }, [fn])
+  return useCallback((...args: any) => {
+    const latestFn = ref.current!
+    return latestFn(...args)
+  }, []) as unknown as T
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,6 @@ importers:
         version: 7.0.2
 
   packages/react-rx:
-    dependencies:
-      use-effect-event:
-        specifier: ^2.0.3
-        version: 2.0.3(react@19.2.8)
     devDependencies:
       '@sanity/tsconfig':
         specifier: ^2.2.1
@@ -4515,11 +4511,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  use-effect-event@2.0.3:
-    resolution: {integrity: sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==}
-    peerDependencies:
-      react: ^18.3 || ^19.0.0-0
 
   use-error-boundary@2.0.6:
     resolution: {integrity: sha512-AWCVKSAanLe6R/on/ZkHYtGKfXs8BQX6z/TUGYqtvkajLqQyrGKJJscbahtq8OyN8L3LqTRjJWx4gCOLmfIObw==}
@@ -9362,10 +9353,6 @@ snapshots:
       browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  use-effect-event@2.0.3(react@19.2.8):
-    dependencies:
-      react: 19.2.8
 
   use-error-boundary@2.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:

--- a/website/src/components/Sandpack.tsx
+++ b/website/src/components/Sandpack.tsx
@@ -73,11 +73,10 @@ export default function SandpackComponent({
         dependencies: {
           /**
            * In production we should always use the package on npm, which supports canaries
-           * while locally we use the build package
+           * while locally we use the build injected above, which has no runtime dependencies
+           * of its own beyond the peer dependencies listed below
            */
-          ...(reactRxSource
-            ? reactRxPackageJson.dependencies
-            : {'react-rx': reactRxPackageJson.version}),
+          ...(reactRxSource ? {} : {'react-rx': reactRxPackageJson.version}),
           'rxjs': reactRxPackageJson.peerDependencies.rxjs,
           'react': reactRxPackageJson.devDependencies.react,
           'react-dom': reactRxPackageJson.devDependencies['react-dom'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed

`packages/react-rx/src/useEffectEvent.ts` no longer re-exports `use-effect-event`. It now holds the implementation vendored from [`use-effect-event@1.0.2`](https://github.com/sanity-io/use-effect-event/blob/v1.0.2/src/useEffectEvent.ts), and the `use-effect-event` runtime dependency is gone from `packages/react-rx/package.json`.

## Why

React Compiler omits `useEffectEvent` from the dependencies it infers only when the hook is React's own. Every other implementation is treated as an ordinary value, so its identity has to stay stable across renders or each memo block and effect closing over it invalidates on every render.

React's native hook and `use-effect-event@2` both return a fresh function per render. That is fine for the native hook, because the compiler knows to ignore it, and not fine for a ponyfill the compiler does not recognise. The 1.0.2 implementation wraps the returned callback in `useCallback(fn, [])`, so the identity really is stable and the compiler's inferred dependency on it is harmless.

The library cannot switch to React's native hook yet: it keeps first-render values inside `memo` and `forwardRef` components ([facebook/react#34818](https://github.com/facebook/react/issues/34818)), which is what the existing `test.fails` cases in `useEffectEvent.test.tsx` pin down.

## Evidence

Measured identity counts across three renders of the same component (`Set` of the returned functions), in both the `default` and `react-compiler` Vitest projects:

| implementation | distinct identities |
| --- | --- |
| `use-effect-event@2.0.3` | 3 |
| `React.useEffectEvent` (19.2) | 3 |
| vendored 1.0.2 | 1 |

`packages/react-rx/src/__tests__/useEffectEvent.test.tsx` gains a `returns the same callback across renders` case so this cannot regress silently.

The built `dist/index.js` shows the effect of the change on the shipped output. `useEffectEvent`'s returned closure sits behind the compiler's memo-cache sentinel, so it is allocated once per component instance, and the only remaining imports are `react`, `react/compiler-runtime`, and `rxjs`.

## Website side effect

`website/src/components/Sandpack.tsx` used to feed react-rx's runtime `dependencies` into Sandpack in development so the injected local build could resolve `use-effect-event`. The build has no runtime dependencies now, so that spread is dropped.

Verified against `pnpm dev`. The Sandpack examples still install, compile, and run interactively, including `/examples/event-handlers`, which exercises `useObservableEvent` and therefore the vendored hook.

[sandpack_examples_demo_clean.mp4](https://cursor.com/agents/bc-b815b2c2-a356-4570-b0b6-50e2574f149c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsandpack_examples_demo_clean.mp4)

[Sandpack event-handlers example running in dev with live mouse coordinates](https://cursor.com/agents/bc-b815b2c2-a356-4570-b0b6-50e2574f149c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsandpack_event_handlers_preview.webp)

## Verification

`pnpm lint`, `pnpm test` (46 files, 426 passed, 4 expected fail, no type errors), `pnpm knip`, and `pnpm build` (publint clean) all pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b815b2c2-a356-4570-b0b6-50e2574f149c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b815b2c2-a356-4570-b0b6-50e2574f149c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

