### PR TITLE
Observable-native Async React demo with an RxJS cache store

### DIFF
--- a/async-react/README.md
+++ b/async-react/README.md
@@ -1,6 +1,21 @@
 # Async React Demo
 
-The final state of the React Conf 2025 Async React talk.
+An Observable-powered adaptation of the final state of Ricky Hanlon's React Conf 2025
+[Async React demo](https://github.com/rickhanlonii/async-react).
+
+The product and design code deliberately keeps React's native async primitives. RxJS owns the
+data layer and `react-rx` connects it to `use()` and Suspense:
+
+- **Ref-counted cache store**: `lessons$` is a keyed observable cache built from RxJS
+  primitives (`src/data/cache.ts`). Concurrent subscribers dedupe into one request, and a result
+  replays for five minutes after it arrives.
+- **Suspense interop**: `useObservablePromise()` turns the shared observable into a promise that a
+  child reads with `use()`; `preloadObservablePromise()` warms the same observable before login
+  navigation.
+- **Invalidation**: mutations and `router.refresh()` clear the store eagerly; `refresh()` then
+  re-renders the route inside a transition so it refetches.
+- **Actions and feedback**: native transitions and `useOptimistic()` keep immediate feedback
+  correctly scheduled while Observable-backed content loads.
 
 View the app: https://async-react.dev/
 
@@ -18,13 +33,20 @@ Run the frontend:
 pnpm --filter async-react dev
 ```
 
+To run the same app without the React Compiler:
+
+```bash
+pnpm --filter async-react dev:no-compiler
+```
+
 The demo is a static Vite app. [MSW](https://mswjs.io) registers a service worker (`public/mockServiceWorker.js`) before React renders. App code uses plain `fetch` against same-origin `/api/*` routes. Handlers in `src/mocks` wrap `fake-data` and apply latency with MSW's `delay()`.
 
 The network debugger posts latency settings to `POST /api/debug/network` (also handled by MSW) so config changes show up as real HTTP requests the same way app traffic does. Each configurable endpoint row has a range input for a fixed delay and a **real** checkbox. When **real** is checked, the range input disables and that handler uses a realistic random delay (MSW's 100–400ms browser range) instead of a fixed millisecond value. The chosen duration is stored so the debugger progress bar can track it; a new random duration is picked when **real** is checked and again after each request starts. Settings persist in `localStorage`. `POST /api/login` has no debugger controls and always responds with `delay('real')`.
 
 ## Motivation
 
-This repo shows the future vision for how product code will be written in React without needing additional APIs.
+This demo shows how product code can keep the same Async React shape when its data layer uses
+Observables. `react-rx` is an interop layer, not a replacement for React's scheduling primitives.
 
 This is possible, but implementing Async React features in:
 
@@ -83,6 +105,7 @@ export default function Home() {
   const search = router.search.q || ''
   const tab = router.search.tab || 'all'
   const revision = router.revision
+  const lessonsPromise = useObservablePromise(data.lessons$(tab, search, revision))
 
   function searchAction(value) {
     router.setParams('q', value)
@@ -99,18 +122,48 @@ export default function Home() {
       <Design.SearchInput value={search} changeAction={searchAction} />
       <Design.TabList activeTab={tab} changeAction={tabAction}>
         <Suspense fallback={<Design.FallbackList />}>
-          <LessonList
-            tab={tab}
-            search={search}
-            revision={revision}
-            completeAction={completeAction}
-          />
+          <LessonList lessonsPromise={lessonsPromise} completeAction={completeAction} />
         </Suspense>
       </Design.TabList>
     </>
   )
 }
 ```
+
+`Home` must not read `lessonsPromise` itself. The Suspense boundary stays between the component
+calling `useObservablePromise()` and the `LessonList` child calling `use(lessonsPromise)`. This lets
+`Home` commit and start the Observable while the child suspends.
+
+The lessons data layer is one declaration on top of a small cache store:
+
+```ts
+export const lessons$ = createObservableCache(
+  (tab, search, _revision) => fetchLessons(lessonsUrl(tab, search)),
+  {ttl: 5 * 60_000},
+)
+
+export function revalidate() {
+  lessons$.clear()
+}
+```
+
+The original demo hand-rolls a `Map<string, Promise>`, a cache key builder, and a `revalidate()`
+the router and every mutation must remember to call. Here the store is what RxJS already offers,
+composed in `src/data/cache.ts`: one `share()` per key with a `ReplaySubject(1)` connector so late
+subscribers get the last result, `resetOnRefCountZero: false` so a request that loses its
+subscribers still completes and populates the cache, and `resetOnComplete: () => timer(ttl)` so a
+result replays for five minutes after it arrives and then releases its key. Every render, Suspense
+retry, and the login page's prefetch of the same key are just subscribers to the same observable, so
+they dedupe into a single request, and switching back to a recent tab replays synchronously with no
+fetch. `react-rx` needs no changes: it keys its promise cache by observable identity, and the store
+is what keeps that identity stable — so none of this depends on compiler-inserted memoization.
+
+Invalidation is the original demo's: mutations and `router.refresh()` call `revalidate()`, which
+drops every entry eagerly, and `refresh()` then bumps `revision` inside a transition so the route
+re-renders, the swap render starts the fresh fetch, and React keeps the previous list visible until
+it settles. `revision` is also an input to `lessons$`, which matters under React Compiler: a compiled
+`Home` only re-reads the store when one of the call's inputs changes, so clearing the store alone
+would not refetch.
 
 When network is fast, the app feels like it's synchronous:
 

--- a/async-react/package.json
+++ b/async-react/package.json
@@ -22,6 +22,8 @@
     "msw": "^2.15.0",
     "react": "canary",
     "react-dom": "canary",
+    "react-rx": "workspace:*",
+    "rxjs": "^7.8.2",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0"

--- a/async-react/package.json
+++ b/async-react/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "build:no-compiler": "vite build --mode no-compiler",
     "dev": "vite",
+    "dev:no-compiler": "vite --mode no-compiler",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },

--- a/async-react/src/app/Home.tsx
+++ b/async-react/src/app/Home.tsx
@@ -1,4 +1,5 @@
 import {Suspense, use, ViewTransition} from 'react'
+import {useObservablePromise, type ObservablePromise} from 'react-rx'
 
 import type {Lesson as LessonItem} from '@/data/fake-data'
 import * as data from '@/data/index'
@@ -29,29 +30,17 @@ function Lesson({
 }
 
 function LessonList({
-  tab,
-  search,
-  revision,
+  lessonsPromise,
   completeAction,
 }: {
-  tab: string
-  search: string
-  revision: number
+  lessonsPromise: ObservablePromise<LessonItem[]>
   completeAction: (id: string) => Promise<void>
 }) {
   /**
-   * data.getLessons is a suspense-enabled data fetching function.
-   * It returns a cached promise that fetched the first time it's called
-   * with a given tab+search+revision, then it returns the resolved data on subsequent calls.
-   *
-   * Since it's cached, there needs to be a way to clear the cache and re-fetch the data,
-   * like after a mutation like toggling complete. This is done with the data.revalidate() function,
-   * which is called in the completeAction below.
-   *
-   * The use(data.getLessons(...)) call here will suspend the component
-   * until the promise resolves, then return the resolved data.
+   * The Suspense boundary sits between Home, which owns the promise, and
+   * this use() call, so Home commits and starts the request while we suspend.
    */
-  const lessons = use(data.getLessons(tab, search, revision))
+  const lessons = use(lessonsPromise)
 
   if (lessons.length === 0) {
     return (
@@ -92,6 +81,11 @@ export default function Home() {
   const search = router.search.q || ''
   const tab = router.search.tab || 'all'
   const revision = router.revision
+  /**
+   * data.lessons$ returns one shared observable per key, so the login page's
+   * prefetch and this render dedupe into the same request.
+   */
+  const lessonsPromise = useObservablePromise(data.lessons$(tab, search, revision))
 
   function searchAction(value: string) {
     /**
@@ -150,12 +144,7 @@ export default function Home() {
            the optimistic/pending states will be used to show loading instead.
         */}
         <Suspense fallback={<Design.FallbackList />}>
-          <LessonList
-            tab={tab}
-            search={search}
-            revision={revision}
-            completeAction={completeAction}
-          />
+          <LessonList lessonsPromise={lessonsPromise} completeAction={completeAction} />
         </Suspense>
       </Design.TabList>
     </>

--- a/async-react/src/data/cache.ts
+++ b/async-react/src/data/cache.ts
@@ -1,0 +1,52 @@
+import {defer, ReplaySubject, share, tap, timer, type Observable, type ObservableInput} from 'rxjs'
+
+export interface ObservableCache<A extends unknown[], T> {
+  /** The shared observable for these arguments; the same instance for the same arguments. */
+  (...args: A): Observable<T>
+  /** Forget every cached result. Live subscribers keep theirs; new ones refetch. */
+  clear(): void
+}
+
+/**
+ * A keyed, ref-counted observable cache for request-like sources (ones that
+ * complete) — the observable-native counterpart of memoize-with-ttl and
+ * request-dedupe libraries.
+ *
+ * Each argument tuple maps to one shared observable. `share` dedupes: every
+ * concurrent subscriber joins the same in-flight request, a request that loses
+ * all its subscribers still runs to completion and populates the cache, and
+ * the result replays to late subscribers for `ttl` after it arrives. Then the
+ * key is released and the next subscriber refetches. Errors are never cached.
+ */
+export function createObservableCache<A extends unknown[], T>(
+  fetch: (...args: A) => ObservableInput<T>,
+  {ttl}: {ttl: number},
+): ObservableCache<A, T> {
+  const entries = new Map<string, Observable<T>>()
+
+  function get(...args: A): Observable<T> {
+    const key = JSON.stringify(args)
+    const cached = entries.get(key)
+    if (cached) {
+      return cached
+    }
+    const shared: Observable<T> = defer(() => fetch(...args)).pipe(
+      share({
+        connector: () => new ReplaySubject<T>(1),
+        resetOnRefCountZero: false,
+        resetOnComplete: () =>
+          timer(ttl).pipe(
+            tap(() => {
+              if (entries.get(key) === shared) {
+                entries.delete(key)
+              }
+            }),
+          ),
+      }),
+    )
+    entries.set(key, shared)
+    return shared
+  }
+
+  return Object.assign(get, {clear: () => entries.clear()})
+}

--- a/async-react/src/data/cache.ts
+++ b/async-react/src/data/cache.ts
@@ -1,4 +1,13 @@
-import {defer, ReplaySubject, share, tap, timer, type Observable, type ObservableInput} from 'rxjs'
+import {
+  defer,
+  of,
+  ReplaySubject,
+  share,
+  tap,
+  timer,
+  type Observable,
+  type ObservableInput,
+} from 'rxjs'
 
 export interface ObservableCache<A extends unknown[], T> {
   /** The shared observable for these arguments; the same instance for the same arguments. */
@@ -16,7 +25,8 @@ export interface ObservableCache<A extends unknown[], T> {
  * concurrent subscriber joins the same in-flight request, a request that loses
  * all its subscribers still runs to completion and populates the cache, and
  * the result replays to late subscribers for `ttl` after it arrives. Then the
- * key is released and the next subscriber refetches. Errors are never cached.
+ * key is released and the next subscriber refetches. An error releases the
+ * key immediately, so failures are never cached and never retained.
  */
 export function createObservableCache<A extends unknown[], T>(
   fetch: (...args: A) => ObservableInput<T>,
@@ -30,18 +40,17 @@ export function createObservableCache<A extends unknown[], T>(
     if (cached) {
       return cached
     }
+    const release = () => {
+      if (entries.get(key) === shared) {
+        entries.delete(key)
+      }
+    }
     const shared: Observable<T> = defer(() => fetch(...args)).pipe(
       share({
         connector: () => new ReplaySubject<T>(1),
         resetOnRefCountZero: false,
-        resetOnComplete: () =>
-          timer(ttl).pipe(
-            tap(() => {
-              if (entries.get(key) === shared) {
-                entries.delete(key)
-              }
-            }),
-          ),
+        resetOnError: () => of(null).pipe(tap(release)),
+        resetOnComplete: () => timer(ttl).pipe(tap(release)),
       }),
     )
     entries.set(key, shared)

--- a/async-react/src/data/index.ts
+++ b/async-react/src/data/index.ts
@@ -1,10 +1,7 @@
+import {preloadObservablePromise} from 'react-rx'
+
+import {createObservableCache} from './cache'
 import type {Lesson, LessonIcon} from './fake-data'
-
-let lessonsCache = new Map<string, Promise<Lesson[]>>()
-
-export function revalidate() {
-  lessonsCache = new Map()
-}
 
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -68,35 +65,31 @@ function fetchLessons(url: string): Promise<Lesson[]> {
   return fetchJson(url).then(parseLessons)
 }
 
-function lessonCacheKey(tab: string, search: string, revision: number): string {
-  return JSON.stringify([tab, search, revision])
-}
-
 function lessonsUrl(tab: string, search: string): string {
   const query = new URLSearchParams({tab, q: search})
   return `/api/lessons?${query}`
 }
 
-export function prefetchLessons(revision: number) {
-  const tab = 'all'
-  const search = ''
-  const promise = fetchLessons(lessonsUrl(tab, search))
-  lessonsCache.set(lessonCacheKey(tab, search, revision), promise)
-  return Promise.race([promise, delay(1000)])
+/**
+ * One shared observable per (tab, search, revision). Concurrent subscribers —
+ * renders, Suspense retries, the login prefetch — dedupe into one request, and
+ * a result replays for five minutes after it arrives. Mutations and
+ * `router.refresh()` call `revalidate()`, which drops every entry eagerly; the
+ * router's `revision` is an input too so a refresh changes what a memoized
+ * render asks for and re-reads the store.
+ */
+export const lessons$ = createObservableCache(
+  (tab: string, search: string, _revision: number) => fetchLessons(lessonsUrl(tab, search)),
+  {ttl: 5 * 60_000},
+)
+
+export function revalidate() {
+  lessons$.clear()
 }
 
-export function getLessons(tab: string, search: string, revision: number): Promise<Lesson[]> {
-  const resolvedTab = tab || 'all'
-  const resolvedSearch = search || ''
-  const key = lessonCacheKey(resolvedTab, resolvedSearch, revision)
-  const cached = lessonsCache.get(key)
-  if (cached) {
-    return cached
-  }
-
-  const promise = fetchLessons(lessonsUrl(resolvedTab, resolvedSearch))
-  lessonsCache.set(key, promise)
-  return promise
+export function prefetchLessons(revision: number) {
+  const promise = preloadObservablePromise(lessons$('all', '', revision))
+  return Promise.race([promise, delay(1000)])
 }
 
 export async function mutateToggle(id: string) {

--- a/async-react/vite.config.ts
+++ b/async-react/vite.config.ts
@@ -2,9 +2,16 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import {defineConfig} from 'vite'
 
-export default defineConfig({
-  plugins: [react({compiler: true}), tailwindcss()],
-  resolve: {
-    tsconfigPaths: true,
-  },
+export default defineConfig(({mode}) => {
+  const useCompiler = mode !== 'no-compiler'
+  return {
+    plugins: [react(useCompiler ? {compiler: true} : {}), tailwindcss()],
+    resolve: {
+      tsconfigPaths: true,
+      // react-rx compiles from workspace source; its sibling node_modules has
+      // its own react/rxjs copies (the library's devDeps), while this app runs
+      // react@canary. Dedupe so the bundle carries exactly one of each.
+      dedupe: ['react', 'react-dom', 'rxjs'],
+    },
+  }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,12 @@ importers:
       react-dom:
         specifier: canary
         version: 19.3.0-canary-f4e439e1-20260902(react@19.3.0-canary-f4e439e1-20260902)
+      react-rx:
+        specifier: workspace:*
+        version: link:../packages/react-rx
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebased onto `current` (react-rx v6.0.1) as two commits; `packages/react-rx` is untouched.

- adapt the Async React demo to RxJS observables through react-rx's existing `useObservablePromise` and `preloadObservablePromise`
- replace the demo's hand-rolled `Map<string, Promise>` data layer with a keyed, ref-counted observable cache store built from RxJS primitives (`async-react/src/data/cache.ts`): `share` with a `ReplaySubject(1)` connector dedupes concurrent subscribers and replays the last result, `resetOnRefCountZero: false` lets a request that loses its subscribers still complete and populate the cache, and `resetOnComplete: () => timer(ttl)` releases a key five minutes after its result arrives
- the lessons data layer is one declaration on that store, so the login prefetch and the page dedupe into a single request and switching back to a recent tab replays synchronously with no fetch
- invalidation is the original demo's: mutations and `router.refresh()` call `revalidate()`, which drops every entry eagerly, and `refresh()` bumps `revision` inside a transition; `revision` is also an input to the store lookup so a compiled `Home` re-reads the store after a refresh (React Compiler memoizes the call on its inputs)
- `vite.config.ts` dedupes `react`, `react-dom`, and `rxjs`: react-rx compiles from workspace source and its sibling `node_modules` carries its own copies (the library's devDeps) while the app runs `react@canary`
- keep native transitions and `useOptimistic` responsible for Action UX; compiler-on/off dev and build modes prove no reliance on compiler memoization

## Design notes

React's async model needs a suspendable read per query so transitions can swap between them, and react-rx keys its promise cache by observable identity. The store is what keeps that identity stable per key, which is why react-rx itself needs no data-fetching concepts — it stays the low-level observable↔React bridge, and dedupe, TTL, and invalidation live in the data layer. The `share` reset configuration was verified empirically against the installed RxJS: `resetOnRefCountZero` never fires after a source completes, so a TTL must hang off `resetOnComplete`.

## Test plan

- [x] react-rx suite untouched and green on `current`
- [x] monorepo lint, knip, demo typecheck and both build modes
- [x] browser against v6, compiler on and off: one deduped `GET /api/lessons` for login prefetch + home, no request on switching back to a cached tab, exactly one refetch after a mutation, no skeleton at any point

## Walkthrough

Both servers on the `current` base — login dedupe, slow tab transition, instant replay on switch-back with no request, mutation with a single refetch and a persisted check, instant 0ms switching:

[rx_store_on_current_v6_both_servers.mp4](https://cursor.com/agents/bc-d849b9b9-fb8a-4054-afa0-6822d2d4d5bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frx_store_on_current_v6_both_servers.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d849b9b9-fb8a-4054-afa0-6822d2d4d5bc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d849b9b9-fb8a-4054-afa0-6822d2d4d5bc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

