### PR TITLE
Pin npm@11 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
           cache: pnpm
           check-latest: true
           node-version: lts/*
+      # Pin npm@11: npm 12 wraps `pnpm info --json` output and changeset publish crashes (changesets/changesets#2274).
       - name: Update npm to use trusted publishing (OIDC)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - run: pnpm install
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`npm install -g npm@latest` now installs npm 12. pnpm's `pnpm info --json` pass-through plus `@changesets/cli@3.0.1` does not unwrap npm 12's array-wrapped output, so `changeset publish` crashes:

`TypeError: Cannot read properties of undefined (reading 'includes')` at `getPublishPlan.mjs:613`

See [changesets/changesets#2274](https://github.com/changesets/changesets/issues/2274). Confirmed on sanity-io/visual-editing run 33517457076.

Pin `npm@11` instead. Trusted publishing still works (`>= 11.5.1`). No other workflow or `@changesets/*` changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9ccb391-214c-4e22-966a-9c22e32e80c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9ccb391-214c-4e22-966a-9c22e32e80c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

