### PR TITLE
Track realistic MSW delay so the debug progress bar can move

### DIFF
--- a/async-react/README.md
+++ b/async-react/README.md
@@ -20,7 +20,7 @@ pnpm --filter async-react dev
 
 The demo is a static Vite app. [MSW](https://mswjs.io) registers a service worker (`public/mockServiceWorker.js`) before React renders. App code uses plain `fetch` against same-origin `/api/*` routes. Handlers in `src/mocks` wrap `fake-data` and apply latency with MSW's `delay()`.
 
-The network debugger posts latency settings to `POST /api/debug/network` (also handled by MSW) so config changes show up as real HTTP requests the same way app traffic does. Each configurable endpoint row has a range input for a fixed delay and a **real** checkbox. When **real** is checked, the range input disables and that handler uses `delay('real')` instead of a fixed millisecond value. Settings persist in `localStorage`. `POST /api/login` has no debugger controls and always responds with `delay('real')`.
+The network debugger posts latency settings to `POST /api/debug/network` (also handled by MSW) so config changes show up as real HTTP requests the same way app traffic does. Each configurable endpoint row has a range input for a fixed delay and a **real** checkbox. When **real** is checked, the range input disables and that handler uses a realistic random delay (MSW's 100–400ms browser range) instead of a fixed millisecond value. The chosen duration is stored so the debugger progress bar can track it; a new random duration is picked when **real** is checked and again after each request starts. Settings persist in `localStorage`. `POST /api/login` has no debugger controls and always responds with `delay('real')`.
 
 ## Motivation
 

--- a/async-react/src/debugger.css
+++ b/async-react/src/debugger.css
@@ -86,20 +86,3 @@ input[type='range']:disabled {
   will-change: transform;
   background: #00bc7d;
 }
-
-.network-progress-indeterminate-bar {
-  position: absolute;
-  inset: 0;
-  width: 40%;
-  background: #00bc7d;
-  animation: network-indeterminate 1.1s ease-in-out infinite;
-}
-
-@keyframes network-indeterminate {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(350%);
-  }
-}

--- a/async-react/src/debugger.ts
+++ b/async-react/src/debugger.ts
@@ -1,6 +1,7 @@
 import {ensureWorker} from './mocks/browser'
 import {
   DEBUG_NETWORK_PATH,
+  realisticLatency,
   type ApiDebugState,
   type ApiPath,
   type DebuggingState,
@@ -99,17 +100,6 @@ function TimedProgress(startMs: number, delayMs: number) {
   return container
 }
 
-function IndeterminateProgress() {
-  const container = document.createElement('div')
-  container.setAttribute('role', 'progressbar')
-  container.setAttribute('aria-label', 'Real network delay')
-  container.className = 'network-progress network-progress-indeterminate'
-  const bar = document.createElement('div')
-  bar.className = 'network-progress-indeterminate-bar'
-  container.appendChild(bar)
-  return container
-}
-
 interface NetworkRow {
   root: HTMLDivElement
   delayLabel: HTMLSpanElement
@@ -119,7 +109,7 @@ interface NetworkRow {
 }
 
 function formatDelayLabel(latency: EndpointLatency): string {
-  return latency.mode === 'real' ? 'real' : `${latency.ms}ms`
+  return `${latency.ms}ms`
 }
 
 function syncControls(row: NetworkRow, latency: EndpointLatency): void {
@@ -143,11 +133,7 @@ function renderRequests(row: NetworkRow, requests: DebugRequest[]): void {
     const label = document.createElement('span')
     label.textContent = request.label
     requestDiv.appendChild(label)
-    requestDiv.appendChild(
-      request.latency.mode === 'real'
-        ? IndeterminateProgress()
-        : TimedProgress(request.start, request.latency.ms),
-    )
+    requestDiv.appendChild(TimedProgress(request.start, request.latency.ms))
     row.requestsDiv.appendChild(requestDiv)
   }
 }
@@ -179,7 +165,7 @@ function createNetworkRow(label: string, id: ApiPath, api: ApiDebugState): Netwo
   realLabel.className = 'network-real-toggle'
   const realCheckbox = document.createElement('input')
   realCheckbox.type = 'checkbox'
-  realCheckbox.title = 'Use MSW delay("real")'
+  realCheckbox.title = 'Use a realistic random network delay'
   realCheckbox.setAttribute('aria-label', `Real latency for ${label}`)
   const realText = document.createElement('span')
   realText.textContent = 'real'
@@ -204,10 +190,9 @@ function createNetworkRow(label: string, id: ApiPath, api: ApiDebugState): Netwo
     postNetworkConfig(id, latency)
   })
   realCheckbox.addEventListener('change', () => {
-    const latency: EndpointLatency = {
-      mode: realCheckbox.checked ? 'real' : 'fixed',
-      ms: Number(slider.value),
-    }
+    const latency: EndpointLatency = realCheckbox.checked
+      ? realisticLatency()
+      : {mode: 'fixed', ms: Number(slider.value)}
     syncControls(row, latency)
     postNetworkConfig(id, latency)
   })

--- a/async-react/src/mocks/debugging.ts
+++ b/async-react/src/mocks/debugging.ts
@@ -2,6 +2,25 @@ export type ApiPath = '/api/lessons' | '/api/lesson/:id/toggle'
 
 export type EndpointLatency = {mode: 'fixed' | 'real'; ms: number}
 
+/** @see https://github.com/mswjs/msw/blob/49d9d47f613b072f8d20e1a025feaee7c5382b2b/src/core/delay.ts */
+const MIN_SERVER_RESPONSE_TIME = 100
+const MAX_SERVER_RESPONSE_TIME = 400
+
+/**
+ * Browser half of MSW's `getRealisticResponseTime()`.
+ * @see https://github.com/mswjs/msw/blob/49d9d47f613b072f8d20e1a025feaee7c5382b2b/src/core/delay.ts#L14-L17
+ */
+function getRealisticResponseTime(): number {
+  return Math.floor(
+    Math.random() * (MAX_SERVER_RESPONSE_TIME - MIN_SERVER_RESPONSE_TIME) +
+      MIN_SERVER_RESPONSE_TIME,
+  )
+}
+
+export function realisticLatency(): EndpointLatency {
+  return {mode: 'real', ms: getRealisticResponseTime()}
+}
+
 export interface DebugRequest {
   id: string
   label: string
@@ -56,7 +75,8 @@ function parseStoredLatency(raw: string | null): EndpointLatency {
 }
 
 function storedLatency(path: ApiPath): EndpointLatency {
-  return parseStoredLatency(localStorage.getItem(path))
+  const stored = parseStoredLatency(localStorage.getItem(path))
+  return stored.mode === 'real' ? realisticLatency() : stored
 }
 
 export function persistLatency(path: ApiPath, latency: EndpointLatency): void {

--- a/async-react/src/mocks/handlers.ts
+++ b/async-react/src/mocks/handlers.ts
@@ -5,8 +5,8 @@ import {DEBUG_NETWORK_PATH} from '@/mocks/debugging'
 import {applyEndpointDelay, parseNetworkConfigBody, setEndpointLatency} from '@/mocks/network-state'
 
 export const handlers = [
-  http.get('/api/lessons', async ({request}) => {
-    await applyEndpointDelay('/api/lessons')
+  http.get('/api/lessons', async ({request, requestId}) => {
+    await applyEndpointDelay('/api/lessons', requestId)
     const url = new URL(request.url)
     const tab = url.searchParams.get('tab') ?? undefined
     const search = url.searchParams.get('q') ?? undefined
@@ -14,8 +14,8 @@ export const handlers = [
     return HttpResponse.json(lessons)
   }),
 
-  http.post<{id: string}>('/api/lesson/:id/toggle', async ({params}) => {
-    await applyEndpointDelay('/api/lesson/:id/toggle')
+  http.post<{id: string}>('/api/lesson/:id/toggle', async ({params, requestId}) => {
+    await applyEndpointDelay('/api/lesson/:id/toggle', requestId)
     await fakeData.postLessonToggle(params.id)
     return HttpResponse.json({status: 'ok'})
   }),

--- a/async-react/src/mocks/network-state.ts
+++ b/async-react/src/mocks/network-state.ts
@@ -6,6 +6,7 @@ import {
   pathnameToApiPath,
   persistLatency,
   isApiPath,
+  realisticLatency,
   type ApiDebugState,
   type ApiPath,
   type DebuggingState,
@@ -31,9 +32,9 @@ export function setEndpointLatency(path: ApiPath, latency: EndpointLatency): voi
   updatePath(path, {latency})
 }
 
-export function applyEndpointDelay(path: ApiPath): Promise<void> {
-  const latency = debuggingState[path].latency
-  return latency.mode === 'real' ? delay('real') : delay(latency.ms)
+export function applyEndpointDelay(path: ApiPath, requestId: string): Promise<void> {
+  const tracked = debuggingState[path].requests.find((request) => request.id === requestId)
+  return delay(tracked?.latency.ms ?? debuggingState[path].latency.ms)
 }
 
 export function trackRequestStart(request: Request, requestId: string): void {
@@ -42,14 +43,22 @@ export function trackRequestStart(request: Request, requestId: string): void {
   if (path == null) {
     return
   }
+  const latency = debuggingState[path].latency
   const debugRequest: DebugRequest = {
     id: requestId,
     label: `${request.method} ${url.pathname}`,
     start: Date.now(),
-    latency: debuggingState[path].latency,
+    latency,
   }
   inFlight.set(requestId, path)
-  updatePath(path, {requests: [...debuggingState[path].requests, debugRequest]})
+  const requests = [...debuggingState[path].requests, debugRequest]
+  if (latency.mode === 'real') {
+    const nextLatency = realisticLatency()
+    persistLatency(path, nextLatency)
+    updatePath(path, {latency: nextLatency, requests})
+    return
+  }
+  updatePath(path, {requests})
 }
 
 export function trackRequestEnd(requestId: string): void {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`delay('real')` picks a random 100–400ms inside MSW, so the network debugger never knew the duration on the wire and had to show an indeterminate bar.

This copies MSW’s browser formula and stores the chosen `ms` on the endpoint (and on each in-flight request). Handlers call `delay(ms)` with that value. A new random time is rolled when **real** is checked and again after each request starts. The debug bar uses the known duration so the progress bar can fill normally.

Login still uses `delay('real')` — it has no debugger row.

It’s a little racy if `request:start` and the handler interleave; `applyEndpointDelay` prefers the tracked request’s snapshotted `ms` when present.

Verified in the demo: checking **real** set 222ms, search/toggle requests showed a determinate green bar, and the stored time rolled after each start (values stayed in 100–399ms). Fixed-delay mode still works.

[Real checked, delay 222ms](https://cursor.com/agents/bc-a3c54c6f-3972-4ea0-9643-61dd3f9fb1d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freal_checked_222ms.webp)
[Determinate progress bar filling during GET /api/lessons](https://cursor.com/agents/bc-a3c54c6f-3972-4ea0-9643-61dd3f9fb1d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprogress_bar_filling_130ms.webp)
[real-delay-progress-bar.mp4](https://cursor.com/agents/bc-a3c54c6f-3972-4ea0-9643-61dd3f9fb1d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freal-delay-progress-bar.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3c54c6f-3972-4ea0-9643-61dd3f9fb1d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3c54c6f-3972-4ea0-9643-61dd3f9fb1d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

