### PR TITLE
test(react-rx): land the v7 test changes that already hold on v6

### DIFF
--- a/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
+++ b/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
@@ -262,7 +262,7 @@ test('a take(1) source latches the first emission and ignores everything after c
 function EditStateProbe({editState$, frames}: {editState$: Observable<string>; frames: string[]}) {
   // `useEditState` reads synchronously: stale edit state paired with live selection
   // would tear (see the deferral-safety section below).
-  frames.push(useSyncObservable(editState$)!)
+  frames.push(useSyncObservable(editState$, undefined)!)
   return null
 }
 
@@ -417,8 +417,8 @@ function SyncSelectionProbe({
   selection$: Observable<string | undefined>
   frames: SelectionFrame[]
 }) {
-  const name = useSyncObservable(selection$)
-  const releases = useSyncObservable(releases$)!
+  const name = useSyncObservable(selection$, undefined)
+  const releases = useSyncObservable(releases$, [])
   frames.push({name, resolved: name !== undefined && releases.includes(name) ? name : undefined})
   return null
 }
@@ -438,8 +438,8 @@ function DeferredSelectionProbe({
   selection$: Observable<string | undefined>
   frames: SelectionFrame[]
 }) {
-  const name = useSyncObservable(selection$)
-  const releases = useObservable(releases$)!
+  const name = useSyncObservable(selection$, undefined)
+  const releases = useObservable(releases$, [])
   frames.push({name, resolved: name !== undefined && releases.includes(name) ? name : undefined})
   return null
 }
@@ -495,8 +495,8 @@ function MixedSyncDeferredProbe({
   releases$: Observable<string[]>
   frames: CrossFrame[]
 }) {
-  const active = useSyncObservable(releases$)!
-  const all = useObservable(releases$)!
+  const active = useSyncObservable(releases$, [])
+  const all = useObservable(releases$, [])
   frames.push({active, all})
   return null
 }
@@ -508,8 +508,8 @@ function AllSyncProbe({
   releases$: Observable<string[]>
   frames: CrossFrame[]
 }) {
-  const active = useSyncObservable(releases$)!
-  const all = useSyncObservable(releases$)!
+  const active = useSyncObservable(releases$, [])
+  const all = useSyncObservable(releases$, [])
   frames.push({active, all})
   return null
 }

--- a/packages/react-rx/src/__tests__/sharedCache.test.tsx
+++ b/packages/react-rx/src/__tests__/sharedCache.test.tsx
@@ -11,10 +11,10 @@ test('useObservable and useSyncObservable share one source subscription for the 
     subscriber.next(subscribeCount++)
   })
 
-  const deferred = renderHook(() => useObservable(observable))
+  const deferred = renderHook(() => useObservable(observable, undefined))
   expect(deferred.result.current).toBe(0)
 
-  const sync = renderHook(() => useSyncObservable(observable))
+  const sync = renderHook(() => useSyncObservable(observable, undefined))
   expect(sync.result.current).toBe(0)
   expect(subscribeCount).toBe(1)
 
@@ -22,7 +22,7 @@ test('useObservable and useSyncObservable share one source subscription for the 
   sync.unmount()
   await Promise.resolve()
 
-  const remount = renderHook(() => useObservable(observable))
+  const remount = renderHook(() => useObservable(observable, undefined))
   expect(remount.result.current).toBe(1)
   remount.unmount()
 })

--- a/packages/react-rx/src/__tests__/strictmode.test.tsx
+++ b/packages/react-rx/src/__tests__/strictmode.test.tsx
@@ -66,7 +66,7 @@ describe.each(hooks)('$name', ({useHook}) => {
     })
 
     function ObservableComponent() {
-      useHook(observable)
+      useHook(observable, undefined)
       return null
     }
 
@@ -89,7 +89,7 @@ describe.each(hooks)('$name', ({useHook}) => {
 
     function ObservableComponent() {
       const memoObservable = useMemo(() => getObservable(), [])
-      useHook(memoObservable)
+      useHook(memoObservable, undefined)
       return null
     }
 

--- a/packages/react-rx/src/__tests__/useObservable.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.activity.test.tsx
@@ -101,7 +101,7 @@ test('Activity hides and restores useObservable subscriptions the same way it do
   })
 
   function Child() {
-    return <div data-testid="value">{useObservable(observable)}</div>
+    return <div data-testid="value">{useObservable(observable, undefined)}</div>
   }
 
   render(
@@ -125,7 +125,7 @@ test('Activity hides and restores useObservable subscriptions the same way it do
   expect(screen.getByTestId('value').style.display).not.toBe('none')
 })
 
-test('sync observable (of/from) without initial value: hide keeps last value, show re-subscribes sync', async () => {
+test('sync observable (of/from) with an undefined initial value: hide keeps last value, show re-subscribes sync', async () => {
   let subscriptions = 0
   // Equivalent to `of('sync')` / `from(['sync'])` for the first emission: sync on subscribe.
   const observable = new Observable<string>((subscriber) => {
@@ -134,7 +134,7 @@ test('sync observable (of/from) without initial value: hide keeps last value, sh
   })
 
   function Child() {
-    return <div data-testid="value">{String(useObservable(observable))}</div>
+    return <div data-testid="value">{String(useObservable(observable, undefined))}</div>
   }
 
   render(
@@ -216,7 +216,7 @@ test('async observable with initial value: shows initial until emission, keeps i
   expect(textOf('value')).toBe('fetched')
 })
 
-test('async observable without initial value: undefined until emission, then preserved across Activity toggles', async () => {
+test('async observable with an undefined initial value: undefined until emission, then preserved across Activity toggles', async () => {
   let resolve!: (value: string) => void
   const promise = new Promise<string>((r) => {
     resolve = r
@@ -224,7 +224,7 @@ test('async observable without initial value: undefined until emission, then pre
   const observable = defer(() => from(promise))
 
   function Child() {
-    return <div data-testid="value">{String(useObservable(observable))}</div>
+    return <div data-testid="value">{String(useObservable(observable, undefined))}</div>
   }
 
   render(
@@ -425,7 +425,7 @@ test('sync from() without initial value under initially-hidden Activity still re
   const observable = from(['from-value'])
 
   function Child() {
-    return <div data-testid="value">{String(useObservable(observable))}</div>
+    return <div data-testid="value">{String(useObservable(observable, undefined))}</div>
   }
 
   render(

--- a/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
@@ -133,11 +133,11 @@ test('useObservable: sync-emitting observable + initialValue server-renders the 
   expect(screen.getByTestId('value').textContent).toBe('sync')
 })
 
-test('useObservable: async observable without initialValue server-renders nothing and hydrates cleanly', async () => {
+test('useObservable: async observable with an undefined initialValue server-renders nothing and hydrates cleanly', async () => {
   const observable = timer(60_000).pipe(map(() => 'later'))
 
   function App() {
-    const value = useObservable(observable)
+    const value = useObservable(observable, undefined)
     return <div data-testid="value">{value ?? ''}</div>
   }
 
@@ -160,7 +160,7 @@ test('useObservable: a NON-deterministic sync emission without an initialValue s
   })
 
   function App() {
-    return <div data-testid="value">{useObservable(observable)}</div>
+    return <div data-testid="value">{useObservable(observable, undefined)}</div>
   }
 
   const html = renderToString(<App />)

--- a/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
@@ -149,7 +149,7 @@ test('releases the last snapshot of an asynchronously completing observable afte
   )
 
   function ObservableComponent() {
-    useObservable(source)
+    useObservable(source, undefined)
     return null
   }
 

--- a/packages/react-rx/src/__tests__/useObservable.test-d.ts
+++ b/packages/react-rx/src/__tests__/useObservable.test-d.ts
@@ -25,3 +25,11 @@ test('useObservable with initial value if a different type returns a union of th
   expectTypeOf(useObservable(observable, () => 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useObservable(observable, 'foo')).toEqualTypeOf<string>()
 })
+
+const double = (n: number) => n * 2
+
+test('a function initial value is provided through an initializer, like useState', () => {
+  const observable = of((n: number) => n + 1)
+
+  expectTypeOf(useObservable(observable, () => double)).toEqualTypeOf<(n: number) => number>()
+})

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -31,7 +31,7 @@ test('should subscribe immediately on component mount and unsubscribe on compone
 
   expect(subscribed).toBe(false)
 
-  const {unmount} = renderHook(() => useObservable(observable))
+  const {unmount} = renderHook(() => useObservable(observable, undefined))
   expect(subscribed).toBe(true)
 
   unmount()
@@ -47,14 +47,14 @@ test('should only subscribe once when given same observable on re-renders', asyn
 
   expect(subscriptionCount).toBe(0)
 
-  const {unmount, rerender} = renderHook(() => useObservable(observable))
+  const {unmount, rerender} = renderHook(() => useObservable(observable, undefined))
   expect(subscriptionCount).toBe(1)
   rerender()
   expect(subscriptionCount).toBe(1)
   unmount()
   await Promise.resolve()
 
-  renderHook(() => useObservable(observable))
+  renderHook(() => useObservable(observable, undefined))
   expect(subscriptionCount).toBe(2)
 })
 
@@ -99,13 +99,13 @@ test('should return undefined during first render if observable is async', () =>
 
 test('should have sync values from an observable as initial value', () => {
   const observable = of('something sync')
-  const {result} = renderHook(() => useObservable(observable))
+  const {result} = renderHook(() => useObservable(observable, undefined))
   expect(result.current).toBe('something sync')
 })
 
 test('should have undefined as initial value from delayed observables', () => {
   const {result, unmount} = renderHook(() =>
-    useObservable(scheduled('something async', asyncScheduler)),
+    useObservable(scheduled('something async', asyncScheduler), undefined),
   )
   expect(result.current).toBeUndefined()
   unmount()
@@ -141,15 +141,15 @@ test('should share the observable between each concurrent subscribing hook', asy
   const observable = new Observable<number>((subscriber) => {
     subscriber.next(subscribeCount++)
   })
-  const firstHook = renderHook(() => useObservable(observable))
+  const firstHook = renderHook(() => useObservable(observable, undefined))
   expect(firstHook.result.current).toBe(0)
-  const secondHook = renderHook(() => useObservable(observable))
+  const secondHook = renderHook(() => useObservable(observable, undefined))
   expect(secondHook.result.current).toBe(0)
   firstHook.unmount()
   secondHook.unmount()
   await Promise.resolve()
 
-  const thirdHook = renderHook(() => useObservable(observable))
+  const thirdHook = renderHook(() => useObservable(observable, undefined))
   expect(thirdHook.result.current).toBe(1)
   thirdHook.unmount()
 })
@@ -198,7 +198,7 @@ test('should restart any completed observable on mount', async () => {
   firstHook.unmount()
   await Promise.resolve()
 
-  const secondHook = renderHook(() => useObservable(observable))
+  const secondHook = renderHook(() => useObservable(observable, undefined))
   expect(secondHook.result.current).toBe(undefined)
   expect(subscribeCount).toBe(2)
   expect(unsubscribeCount).toBe(1)
@@ -210,7 +210,7 @@ test('should restart any completed observable on mount', async () => {
 
 test('should update with values from observables', () => {
   const values$ = new Subject<string>()
-  const {result, unmount} = renderHook(() => useObservable(values$))
+  const {result, unmount} = renderHook(() => useObservable(values$, undefined))
 
   expect(result.current).toBe(undefined)
 
@@ -285,7 +285,7 @@ test('identity change without an initialValue renders the new observable synchro
   const renderTimeline: (string | undefined)[] = []
 
   function ObservableComponent({observable}: {observable: BehaviorSubject<string>}) {
-    renderTimeline.push(useObservable(observable))
+    renderTimeline.push(useObservable(observable, undefined))
     return null
   }
   const {rerender, unmount} = render(<ObservableComponent observable={subjectA} />)

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -272,6 +272,7 @@ test('falls back to the live value when the observable identity changes (deferra
   // snapshot belonging to the previous observable.
   expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial for b')
   expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+  expect(renderTimeline.at(-1)).toBe('initial for b')
 
   act(() => subjectB.next('updated for b'))
   expect(renderTimeline.at(-1)).toBe('updated for b')
@@ -298,6 +299,7 @@ test('identity change without an initialValue renders the new observable synchro
   // render after the identity change already shows subjectB's synchronous emission.
   expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial for b')
   expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+  expect(renderTimeline.at(-1)).toBe('initial for b')
 
   unmount()
 })

--- a/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
@@ -4,7 +4,11 @@ import {createRoot} from 'react-dom/client'
 import {BehaviorSubject} from 'rxjs'
 import {expect, test} from 'vitest'
 
-import {useObservablePromise, type ObservablePromise} from '../useObservablePromise'
+import {
+  preloadObservablePromise,
+  useObservablePromise,
+  type ObservablePromise,
+} from '../useObservablePromise'
 
 /**
  * Port of the dai-shi concurrent-rendering tearing checks relevant to external
@@ -28,9 +32,28 @@ async function renderAsync(ui: ReactNode) {
   return result
 }
 
+/**
+ * Settle the counter store before anything mounts: the tearing checks below
+ * measure store consistency across many readers (not Suspense fallback churn),
+ * and the mount-during-transition tests emit into the store before any
+ * consumer commits — the preload's shared connection is what keeps the cached
+ * promise current until then. Preloading a BehaviorSubject settles it
+ * synchronously, matching how a real app would warm a store before mounting an
+ * expensive subtree.
+ */
+function warmedCounterStore(initial = 0) {
+  const count$ = new BehaviorSubject(initial)
+  void preloadObservablePromise(count$, {ttl: 60_000})
+  return count$
+}
+
 function slowFib(n: number): number {
   if (n <= 1) return n
   return slowFib(n - 1) + slowFib(n - 2)
+}
+
+function CounterValue({promise, index}: {promise: ObservablePromise<number>; index: number}) {
+  return <span data-testid={`c-${index}`}>{use(promise)}</span>
 }
 
 function Counter({
@@ -42,10 +65,17 @@ function Counter({
   index: number
   waste?: number
 }) {
-  const value = use(useObservablePromise(count$))
+  // Hook caller above the boundary, use() reader below it — the sanctioned
+  // shape, so the caller can commit (starting/holding the subscription) even
+  // while the reader suspends.
+  const promise = useObservablePromise(count$)
   // Artificial expensive render to widen the concurrent window.
   slowFib(waste)
-  return <span data-testid={`c-${index}`}>{value}</span>
+  return (
+    <Suspense fallback={null}>
+      <CounterValue promise={promise} index={index} />
+    </Suspense>
+  )
 }
 
 function readAll(): number[] {
@@ -53,7 +83,7 @@ function readAll(): number[] {
 }
 
 test('no tearing finally on update (startTransition)', async () => {
-  const count$ = new BehaviorSubject(0)
+  const count$ = warmedCounterStore()
 
   function App() {
     const [, startTransition] = useTransition()
@@ -92,7 +122,7 @@ test('no tearing finally on update (startTransition)', async () => {
 })
 
 test('no tearing finally on mount (startTransition)', async () => {
-  const count$ = new BehaviorSubject(0)
+  const count$ = warmedCounterStore()
 
   function App() {
     const [mounted, setMounted] = useState(false)
@@ -132,7 +162,7 @@ test('no tearing finally on mount (startTransition)', async () => {
 })
 
 test('no tearing finally on update (useDeferredValue)', async () => {
-  const count$ = new BehaviorSubject(0)
+  const count$ = warmedCounterStore()
 
   function App() {
     const [version, setVersion] = useState(0)
@@ -169,7 +199,7 @@ test('no tearing finally on update (useDeferredValue)', async () => {
 })
 
 test('no tearing finally on mount (useDeferredValue)', async () => {
-  const count$ = new BehaviorSubject(0)
+  const count$ = warmedCounterStore()
 
   function App() {
     const [mounted, setMounted] = useState(false)
@@ -276,18 +306,23 @@ function DeferredSection({promise, waste}: {promise: ObservablePromise<number>; 
   return <SlowList promise={deferred} waste={waste} />
 }
 
+function ImmediateValue({promise}: {promise: ObservablePromise<number>}) {
+  return <span data-testid="immediate">{use(promise)}</span>
+}
+
 function InterruptibleApp({count$, waste}: {count$: BehaviorSubject<number>; waste: number}) {
   const promise = useObservablePromise(count$)
-  const immediate = use(promise)
   const [urgent, setUrgent] = useState(0)
   return (
     <>
       <button type="button" onClick={() => setUrgent((n) => n + 1)}>
         urgent
       </button>
-      <span data-testid="immediate">{immediate}</span>
       <span data-testid="urgent">{urgent}</span>
-      <DeferredSection promise={promise} waste={waste} />
+      <Suspense fallback={null}>
+        <ImmediateValue promise={promise} />
+        <DeferredSection promise={promise} waste={waste} />
+      </Suspense>
     </>
   )
 }
@@ -296,7 +331,7 @@ test('userland useDeferredValue(promise) restores time slicing for emission-driv
   // ≥4ms per item × 25 items ⇒ ≥100ms of deferred render work, sliced into
   // many ~5ms scheduler chunks with yields in between.
   const waste = calibrateWaste(4)
-  const count$ = new BehaviorSubject(0)
+  const count$ = warmedCounterStore()
 
   // act() flushes sync and deferred work together, hiding exactly the
   // interleaving this test observes — so run without the act environment,

--- a/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
@@ -52,10 +52,6 @@ function slowFib(n: number): number {
   return slowFib(n - 1) + slowFib(n - 2)
 }
 
-function CounterValue({promise, index}: {promise: ObservablePromise<number>; index: number}) {
-  return <span data-testid={`c-${index}`}>{use(promise)}</span>
-}
-
 function Counter({
   count$,
   index,
@@ -65,17 +61,10 @@ function Counter({
   index: number
   waste?: number
 }) {
-  // Hook caller above the boundary, use() reader below it — the sanctioned
-  // shape, so the caller can commit (starting/holding the subscription) even
-  // while the reader suspends.
-  const promise = useObservablePromise(count$)
+  const value = use(useObservablePromise(count$))
   // Artificial expensive render to widen the concurrent window.
   slowFib(waste)
-  return (
-    <Suspense fallback={null}>
-      <CounterValue promise={promise} index={index} />
-    </Suspense>
-  )
+  return <span data-testid={`c-${index}`}>{value}</span>
 }
 
 function readAll(): number[] {

--- a/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
@@ -34,30 +34,35 @@ async function forceGC() {
   }
 }
 
+function Reader({promise}: {promise: Promise<string>}) {
+  const value = use(promise)
+  return <div data-testid="v">{value}</div>
+}
+
+function PayloadReader({promise}: {promise: Promise<{payload: string}>}) {
+  return <>{use(promise).payload.length}</>
+}
+
 test('sync termination does not leave a poisoned cache entry', async () => {
   const observable = of('sync')
 
-  function Child() {
-    const value = use(useObservablePromise(observable, {ttl: 20}))
-    return <div data-testid="v">{value}</div>
+  function Owner() {
+    const p = useObservablePromise(observable, {ttl: 20})
+    return (
+      <Suspense fallback={<div>loading</div>}>
+        <Reader promise={p} />
+      </Suspense>
+    )
   }
 
-  const {unmount} = await renderAsync(
-    <Suspense fallback={<div>loading</div>}>
-      <Child />
-    </Suspense>,
-  )
+  const {unmount} = await renderAsync(<Owner />)
   expect(screen.getByTestId('v').textContent).toBe('sync')
   unmount()
   await wait(40)
 
   // Remount after eviction should succeed (fresh subscription), not replay a
   // stale error or hang.
-  await renderAsync(
-    <Suspense fallback={<div>loading</div>}>
-      <Child />
-    </Suspense>,
-  )
+  await renderAsync(<Owner />)
   expect(screen.getByTestId('v').textContent).toBe('sync')
 })
 
@@ -89,17 +94,17 @@ test('releases the settled value and promise after unmount and ttl expiry', asyn
     return of(value)
   })
 
-  function Child() {
+  function Owner() {
     const promise = useObservablePromise(source, {ttl: 20})
     promiseRefs.push(new WeakRef(promise))
-    return <>{use(promise).payload.length}</>
+    return (
+      <Suspense fallback={null}>
+        <PayloadReader promise={promise} />
+      </Suspense>
+    )
   }
 
-  const {unmount} = await renderAsync(
-    <Suspense fallback={null}>
-      <Child />
-    </Suspense>,
-  )
+  const {unmount} = await renderAsync(<Owner />)
   unmount()
   // Let the eviction timer fire, releasing the cache entry (which retains both
   // the instrumented promise and, through it, the settled value).
@@ -146,16 +151,16 @@ test('unmount after async settle allows remount after ttl to refetch', async () 
     )
   })
 
-  function Child() {
-    const value = use(useObservablePromise(observable, {ttl: 40}))
-    return <div data-testid="v">{value}</div>
+  function Owner() {
+    const p = useObservablePromise(observable, {ttl: 40})
+    return (
+      <Suspense fallback={<div data-testid="fallback">loading</div>}>
+        <Reader promise={p} />
+      </Suspense>
+    )
   }
 
-  const {unmount} = await renderAsync(
-    <Suspense fallback={<div>loading</div>}>
-      <Child />
-    </Suspense>,
-  )
+  const {unmount} = await renderAsync(<Owner />)
   await act(async () => {
     resolvers[0]!('one')
   })
@@ -163,11 +168,7 @@ test('unmount after async settle allows remount after ttl to refetch', async () 
   unmount()
   await wait(70)
 
-  await renderAsync(
-    <Suspense fallback={<div data-testid="fallback">loading</div>}>
-      <Child />
-    </Suspense>,
-  )
+  await renderAsync(<Owner />)
   expect(screen.getByTestId('fallback')).toBeTruthy()
   expect(subscriptions).toBe(2)
   await act(async () => {

--- a/packages/react-rx/src/__tests__/useObservablePromise.strictmode.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.strictmode.test.tsx
@@ -13,7 +13,12 @@ async function renderAsync(ui: ReactNode) {
   return result
 }
 
-test('StrictMode double-mount does not double-subscribe beyond the share contract', async () => {
+function Reader({promise}: {promise: Promise<string>}) {
+  const value = use(promise)
+  return <div data-testid="value">{value}</div>
+}
+
+test('StrictMode double effects do not double-subscribe beyond the share contract', async () => {
   let subscriptions = 0
   let resolve!: (value: string) => void
   const promise = new Promise<string>((r) => {
@@ -37,7 +42,8 @@ test('StrictMode double-mount does not double-subscribe beyond the share contrac
     </StrictMode>,
   )
 
-  // Share + retention must collapse StrictMode double invoke to a single source sub.
+  // StrictMode runs subscribe → unsubscribe → resubscribe; share + retention
+  // must collapse that to a single source subscription.
   expect(subscriptions).toBe(1)
 
   await act(async () => {
@@ -48,23 +54,25 @@ test('StrictMode double-mount does not double-subscribe beyond the share contrac
   expect(subscriptions).toBe(1)
 })
 
-test('StrictMode keeps a stable promise identity across double effects', async () => {
+test('StrictMode keeps a stable promise identity across double renders and effects', async () => {
   const identities: Promise<string>[] = []
   const observable = new Observable<string>((subscriber) => {
     subscriber.next('sync')
   })
 
-  function Child() {
+  function Owner() {
     const p = useObservablePromise(observable)
     identities.push(p)
-    return <div data-testid="value">{use(p)}</div>
+    return (
+      <Suspense fallback={<div>loading</div>}>
+        <Reader promise={p} />
+      </Suspense>
+    )
   }
 
   await renderAsync(
     <StrictMode>
-      <Suspense fallback={<div>loading</div>}>
-        <Child />
-      </Suspense>
+      <Owner />
     </StrictMode>,
   )
 

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -781,9 +781,6 @@ test('flipping disabled to false starts the fetch and resolves the same promise 
 
 test('disabled component sharing a warmed entry gets the settled promise', async () => {
   const observable = of('warm')
-  // Settle the shared entry before anything renders — a disabled consumer
-  // performs no fetching of its own and only re-reads on its own re-renders.
-  void preloadObservablePromise(observable)
 
   function Warmed() {
     const p = useObservablePromise(observable)

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -781,6 +781,9 @@ test('flipping disabled to false starts the fetch and resolves the same promise 
 
 test('disabled component sharing a warmed entry gets the settled promise', async () => {
   const observable = of('warm')
+  // Settle the shared entry before anything renders — a disabled consumer
+  // performs no fetching of its own and only re-reads on its own re-renders.
+  void preloadObservablePromise(observable)
 
   function Warmed() {
     const p = useObservablePromise(observable)

--- a/packages/react-rx/src/__tests__/useSyncObservable.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.activity.test.tsx
@@ -59,7 +59,7 @@ test('Activity hides and restores useSyncObservable subscriptions the same way i
   })
 
   function Child() {
-    return <div data-testid="value">{useSyncObservable(observable)}</div>
+    return <div data-testid="value">{useSyncObservable(observable, undefined)}</div>
   }
 
   render(

--- a/packages/react-rx/src/__tests__/useSyncObservable.test-d.ts
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test-d.ts
@@ -25,3 +25,11 @@ test('useSyncObservable with initial value if a different type returns a union o
   expectTypeOf(useSyncObservable(observable, () => 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useSyncObservable(observable, 'foo')).toEqualTypeOf<string>()
 })
+
+const double = (n: number) => n * 2
+
+test('a function initial value is provided through an initializer, like useState', () => {
+  const observable = of((n: number) => n + 1)
+
+  expectTypeOf(useSyncObservable(observable, () => double)).toEqualTypeOf<(n: number) => number>()
+})

--- a/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
@@ -29,7 +29,7 @@ test('should subscribe immediately on component mount and unsubscribe on compone
 
   expect(subscribed).toBe(false)
 
-  const {unmount} = renderHook(() => useSyncObservable(observable))
+  const {unmount} = renderHook(() => useSyncObservable(observable, undefined))
   expect(subscribed).toBe(true)
 
   unmount()
@@ -45,14 +45,14 @@ test('should only subscribe once when given same observable on re-renders', asyn
 
   expect(subscriptionCount).toBe(0)
 
-  const {unmount, rerender} = renderHook(() => useSyncObservable(observable))
+  const {unmount, rerender} = renderHook(() => useSyncObservable(observable, undefined))
   expect(subscriptionCount).toBe(1)
   rerender()
   expect(subscriptionCount).toBe(1)
   unmount()
   await Promise.resolve()
 
-  renderHook(() => useSyncObservable(observable))
+  renderHook(() => useSyncObservable(observable, undefined))
   expect(subscriptionCount).toBe(2)
 })
 
@@ -97,7 +97,7 @@ test('should return undefined during first render if observable is async', () =>
 
 test('should have sync values from an observable as initial value', () => {
   const observable = of('something sync')
-  const {result} = renderHook(() => useSyncObservable(observable))
+  const {result} = renderHook(() => useSyncObservable(observable, undefined))
   expect(result.current).toBe('something sync')
 })
 
@@ -141,7 +141,7 @@ test('disabled with an initialValue never subscribes the source (zero subscripti
 
 test('should have undefined as initial value from delayed observables', () => {
   const {result, unmount} = renderHook(() =>
-    useSyncObservable(scheduled('something async', asyncScheduler)),
+    useSyncObservable(scheduled('something async', asyncScheduler), undefined),
   )
   expect(result.current).toBeUndefined()
   unmount()
@@ -177,15 +177,15 @@ test('should share the observable between each concurrent subscribing hook', asy
   const observable = new Observable<number>((subscriber) => {
     subscriber.next(subscribeCount++)
   })
-  const firstHook = renderHook(() => useSyncObservable(observable))
+  const firstHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(firstHook.result.current).toBe(0)
-  const secondHook = renderHook(() => useSyncObservable(observable))
+  const secondHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(secondHook.result.current).toBe(0)
   firstHook.unmount()
   secondHook.unmount()
   await Promise.resolve()
 
-  const thirdHook = renderHook(() => useSyncObservable(observable))
+  const thirdHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(thirdHook.result.current).toBe(1)
   thirdHook.unmount()
 })
@@ -234,7 +234,7 @@ test('should restart any completed observable on mount', async () => {
   firstHook.unmount()
   await Promise.resolve()
 
-  const secondHook = renderHook(() => useSyncObservable(observable))
+  const secondHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(secondHook.result.current).toBe(undefined)
   expect(subscribeCount).toBe(2)
   expect(unsubscribeCount).toBe(1)
@@ -246,7 +246,7 @@ test('should restart any completed observable on mount', async () => {
 
 test('should update with values from observables', () => {
   const values$ = new Subject<string>()
-  const {result, unmount} = renderHook(() => useSyncObservable(values$))
+  const {result, unmount} = renderHook(() => useSyncObservable(values$, undefined))
 
   expect(result.current).toBe(undefined)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#515 carries +2989/-2044 lines, and 2792 of them are in test files. Part of that test delta does not depend on the v7 behavior changes. It passes on `current` today and says nothing that is false on v6. This PR lands that part, so #515 gets smaller and its remaining test diff is only what v7 changes.

## Scope

Five commits, 14 files under `packages/react-rx/src/__tests__`, +147/-96. Every changed line is byte-identical to the `next` branch (`64c353c` at the time of writing).

1. `useObservable` and `useSyncObservable` calls pass `initialValue` explicitly. Most pass `undefined`. The selection probes in `sanityStreamShapes.test.tsx` pass `[]` instead of a non-null assertion. On v6 an explicit `undefined` is the same as omitting the argument, because both hooks check `typeof initialValue !== 'undefined'`. Two test titles change from "without initial value" to "with an undefined initial value". The rule a v6 reader needs: explicit `undefined` marks the calls that survive into v7. The calls that stay bare sit inside tests v7 deletes (the warm-up tests), so this split cannot be completed on `current`. If you would rather not carry a half-applied convention on v6, drop commit `357f0e0` and let those 92 lines ride in #515.
2. `useObservablePromise.leaks.test.tsx` takes the v7 file whole. The hook caller renders the `Suspense` boundary and hands the promise to a `Reader` child that calls `use()`. v7 needs that shape. v6 accepts both. One coverage shift comes with it. `Owner` commits before an async source settles, so the remount-after-ttl test in this file no longer exercises v6's eviction race where the source settles with zero committed subscribers. `useObservablePromise.test.tsx` and the first strictmode test still cover that path. `useObservablePromise.concurrent.test.tsx` takes the `warmedCounterStore()` preload helper and the `InterruptibleApp` restructure. On v6 the preload changes nothing these tests observe, because `entry.ensure` already settles a `BehaviorSubject` during the first render. It does extend the entry's retention to 60s. v7 needs it. `useObservablePromise.strictmode.test.tsx` takes the shared `Reader`, both renamed titles, and the Owner/Reader shape for the promise-identity test. The first test keeps its `Child` shape because its v7 hunk carries a comment that is false on v6, so the file has one test in each shape.
3. Two type tests for function initial values (`useObservable(fn$, () => double)` has the type of `double`) and two final-value assertions in the identity-change tests of `useObservable.test.tsx`.

Commits `9231dec` and `aae66c5` apply a cross-model review of the first three. `9231dec` reverts the `Counter` restructure in the concurrent file and a preload in `useObservablePromise.test.tsx`, both from `9ed3008`. `aae66c5` adds the strictmode subset. A squash merge hides that churn if you prefer.

Left in #515 on purpose, even where the tests pass on v6:

- `useObservablePromise.transitions.test.tsx` (520 lines). It passes on v6 because v6 fetches during every render, so every "starts the fetch" assertion holds. Its header describes the v7 live-swap eager start and states that mounts stay lazy, which v6 contradicts.
- Deleted tests for behavior v6 still ships. `useObservableEvent.*`, `useEffectEvent.test.tsx`, the warm-up leak regressions in `useObservable.leaks.test.tsx`, `should not return undefined during render if observable is sync`, and `should throw during SSR if no initial value is defined`.
- Titles and comments that assert v7 semantics. Never subscribed during render, initializer runs once, SSR never throws, hidden trees never fetch, and the two Owner/Reader hunks whose comments say commit is what starts the fetch (`Counter` in the concurrent file, the first test in the strictmode file). On v6 `entry.ensure(ttl, !disabled)` starts the source during render.
- The preload in the disabled-consumer test of `useObservablePromise.test.tsx`. On v6 that test proves the enabled sibling warms the entry during render. A preload would hide that.

## Tradeoffs

The rule was to take a hunk only when it passes on `current` and its statements hold on v6. Taking everything that passes would carry +822/-1031 lines and shrink #515 to 3180 changed lines. It also deletes v6 coverage, documents v7 mechanics on v6, and `sanityStreamShapes.test.tsx` conflicts when merged back into `next`. The conservative set shrinks #515 from 5033 to 4790 changed lines.

The `[]` initial values in `sanityStreamShapes.test.tsx` skip the v6 render-phase warm-up for those probes. Those tests check tearing between sync and deferred reads on updates, which the store subscription drives on both versions, so I kept them. Drop that hunk if you would rather keep the probe path there.

Files were composed from `origin/current` plus selected `-U0` hunks of `git diff origin/current origin/next`, never edited by hand. That is what keeps every line identical to `next`.

## Blast Radius

Tests only. No source, config, or website changes. The suite keeps all 424 tests and gains 2 type tests. Merging `current` into `next` after this lands leaves `next` unchanged.

## Verification

`pnpm lint`, `pnpm test`, and `pnpm knip` on the branch head. Lint clean. 426 passed and 4 expected fail across 46 files, in both the default and the react-compiler project. Knip clean. Each of the five commits passed lint, the full suite, and the merge gate on its own.

Merge gate. In a scratch worktree, merging this branch into `origin/next` completes without conflicts and produces the same tree as merging plain `origin/current` into `origin/next`. So `next` already contains every line here. A planted one-word deviation makes the same gate fail with a conflict. Verified against `origin/current` `a7b87d4` and `origin/next` `64c353c`. If `next` moves, re-run:

```sh
git fetch origin current next cursor/split-515-tests-528b
git worktree add /tmp/next-wt origin/next --detach
git -C /tmp/next-wt merge --no-edit origin/current && git -C /tmp/next-wt tag plain
git -C /tmp/next-wt reset --hard origin/next
git -C /tmp/next-wt merge --no-edit origin/cursor/split-515-tests-528b
git -C /tmp/next-wt diff --stat plain
```

The last command prints nothing.

Delta before and after. `git diff --shortstat origin/current origin/next` gives 89 files, +2989/-2044. `git diff --shortstat origin/cursor/split-515-tests-528b origin/next` gives 87 files, +2842/-1948.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3454fdc4-aea3-4e8f-a2eb-95c29d88528b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3454fdc4-aea3-4e8f-a2eb-95c29d88528b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

